### PR TITLE
refactor: shared pub_fig_style (fix Arial bug) + CLAUDE.md motif docs + git/seff commands

### DIFF
--- a/.claude/commands/git-wrap.md
+++ b/.claude/commands/git-wrap.md
@@ -1,0 +1,42 @@
+---
+description: Wrap up a work session with clean git hygiene (audit → group commits → PR → cleanup)
+---
+
+Help wrap up this coding session with clean git hygiene. Optional context from the user: $ARGUMENTS
+
+Follow these steps, confirming with me before any irreversible or outward-facing action:
+
+1. **Audit.** Run `git branch --show-current`, `git status --short`, and
+   `git log --oneline main..HEAD` (commits not yet on main) plus
+   `git log --oneline origin/main..HEAD`. Distinguish:
+   - commits already pushed/merged,
+   - local commits not pushed,
+   - uncommitted working-tree changes (and whether they're from THIS session
+     or pre-existing leftovers — do not assume they're mine).
+
+2. **Group.** Propose logical commit groupings by theme (don't sweep unrelated
+   changes into one commit). Show me the groupings and proposed commit messages.
+   Wait for my confirmation before committing.
+
+3. **Branch discipline.** If on `main` (default branch), propose creating a
+   feature branch first unless I explicitly say commit-to-main. Never push to
+   the default branch without explicit confirmation.
+
+4. **Commit + push.** After I confirm, commit in the agreed groups and push the
+   branch.
+
+5. **PR.** Draft a PR title + concise body (summary + scope). Show me before
+   opening. End the body with the Claude Code attribution footer.
+
+6. **Cleanup + report.** After merge (when I confirm), update local main
+   (`git fetch && git merge --ff-only origin/main`), delete merged branches,
+   and report any leftover untracked files that may need `.gitignore` entries.
+   Verify `git status` is clean at the end.
+
+Reminders:
+- `git stash` is the reversible move when a branch switch is blocked by tracked
+  edits whose intent is unclear.
+- `.gitignore` never deletes on-disk files — after adding ignore rules for
+  generated dirs, confirm with `ls` that the files remain.
+- Tracked files under a gitignored dir can't be re-`git add`ed without `-f` —
+  honor the convention (e.g. `outputs/` = build artifacts) rather than forcing.

--- a/.claude/commands/seff-check.md
+++ b/.claude/commands/seff-check.md
@@ -1,0 +1,33 @@
+---
+description: Audit a completed SLURM job's resource usage with seff and record it (enforces the workspace CLAUDE.md mandate)
+---
+
+Audit SLURM job resource usage. Usage: `/seff-check <jobid> [job-type]`
+Arguments: $ARGUMENTS
+
+This command ENFORCES the workspace-level mandate in
+`/hpc/projects/data.science/yangjoon.kim/CLAUDE.md` (SLURM Resource Monitoring
+Workflow) — it is not a new optional process; it codifies a required one.
+
+Steps:
+
+1. Run `seff <jobid>` and parse: requested vs. actual CPUs, memory, walltime,
+   and the CPU / memory efficiency percentages.
+
+2. Flag against these thresholds:
+   - Memory efficiency < 50% → recommend a lower `--mem`
+   - CPU efficiency < 50% → recommend fewer `--cpus-per-task`
+   - Walltime used < 25% of requested → recommend a shorter `--time`
+   - Exit due to OOM → note the minimum memory needed
+
+3. Record the finding in the memory file `slurm-resources.md` (per the
+   workspace CLAUDE.md). Use a consistent row:
+   `| <date> | <job-type> | <jobid> | req: CPUs/mem/time | actual: CPU%/mem/walltime | recommendation |`
+
+4. If `slurm-resources.md` already has an entry for the same job-type, show the
+   delta vs. the last run and whether prior recommendations were applied.
+
+5. Give a one-line recommended `sbatch` resource line for the next similar job.
+
+Keep it concise — this runs after every SLURM job, so the output should be a
+quick scannable audit, not an essay.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,29 @@ The peak metadata cache parquet (gitignored) lives at:
 Sanity-tested on `pax2a` (33 peaks, MHB) and `sox10` (26 peaks, neural
 crest). Total runtime ~1–3 min per gene.
 
+## Peak Parts List — Multi-Database Motif Rescan (`notebooks/EDA_peak_parts_list/`)
+
+Batch FIMO motif scanning of the **top-200 peaks per celltype** (31 celltypes
+≈ 6,200 peaks) — distinct from the per-gene `run_fimo_on_peaks.py` above.
+Scans three motif databases for cross-database robustness:
+
+| Database | Scope | Output suffix |
+|---|---|---|
+| **H12CORE** (default) | HOCOMOCO v12 CORE, broad vertebrate (~1,443 PWMs) | none |
+| **JASPAR 2024** | clustered consensus profiles (182 PWMs) | `_jaspar` |
+| **CIS-BP v2 (Danio rerio)** | zebrafish-specific (~5,300 PWMs) | `_cisbp` |
+
+Key scripts (in `notebooks/EDA_peak_parts_list/`):
+- `09j_fimo_batch.py` — batch FIMO runner, `--motif-db {h12core,jaspar2024,cisbpv2_danrer}`
+- `09j_convert_cisbp_pfm_to_meme.py` — CIS-BP PFM → MEME conversion
+- `09j_precompute_motif_hits_top200.py` — precompute hit matrix for downstream panels
+- `09j_merge_and_test.py` — merge per-celltype FIMO + Fisher's-exact enrichment
+- `09i_motif_position_maps.py` — per-peak motif position maps
+- Per-DB SLURM runners: `slurm/run_09j_{fimo_array,merge}_{jaspar2024,cisbpv2}.sh`
+
+Scratch outputs: `/hpc/scratch/group.data.science/yang-joon.kim/peak-parts-list-motifs/`
+Reference: `notebooks/EDA_peak_parts_list/MOTIF_DATABASES.md` (+ `MOTIF_RESCAN_PLAN.md`)
+
 ## Development Workflow
 
 ### Working with Notebooks

--- a/scripts/utils/compare_motif_function_across_celltypes.py
+++ b/scripts/utils/compare_motif_function_across_celltypes.py
@@ -22,14 +22,10 @@ import os, sys, argparse
 import numpy as np
 import pandas as pd
 
-import matplotlib as _mpl
-_mpl.rcParams.update(_mpl.rcParamsDefault)
-_mpl.rcParams['font.family'] = 'Arial'
-_mpl.rcParams["pdf.fonttype"] = 42
-_mpl.rcParams["ps.fonttype"]  = 42
-import seaborn as _sns
-_sns.set(style="whitegrid", context="paper")
-_mpl.rcParams["savefig.dpi"]  = 300
+# ── Publication figure settings (shared module: scripts/utils/pub_fig_style.py) ──
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pub_fig_style import apply as _apply_pub_style
+_apply_pub_style()
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 

--- a/scripts/utils/design_short_element.py
+++ b/scripts/utils/design_short_element.py
@@ -30,14 +30,10 @@ import os, sys, argparse
 import numpy as np
 import pandas as pd
 
-import matplotlib as _mpl
-_mpl.rcParams.update(_mpl.rcParamsDefault)
-_mpl.rcParams['font.family'] = 'Arial'
-_mpl.rcParams["pdf.fonttype"] = 42
-_mpl.rcParams["ps.fonttype"]  = 42
-import seaborn as _sns
-_sns.set(style="whitegrid", context="paper")
-_mpl.rcParams["savefig.dpi"]  = 300
+# ── Publication figure settings (shared module: scripts/utils/pub_fig_style.py) ──
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pub_fig_style import apply as _apply_pub_style
+_apply_pub_style()
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.gridspec as gridspec

--- a/scripts/utils/make_peak_3panel_figures.py
+++ b/scripts/utils/make_peak_3panel_figures.py
@@ -30,19 +30,13 @@ import numpy as np
 import pandas as pd
 import anndata as ad
 
-# ── Publication figure settings ──
-import matplotlib as _mpl
-_mpl.rcParams.update(_mpl.rcParamsDefault)
-_mpl.rcParams['font.family'] = 'Arial'
-_mpl.rcParams["pdf.fonttype"] = 42
-_mpl.rcParams["ps.fonttype"]  = 42
-import seaborn as _sns
-_sns.set(style="whitegrid", context="paper")
-_mpl.rcParams["savefig.dpi"]  = 300
+# ── Publication figure settings (shared module: scripts/utils/pub_fig_style.py) ──
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pub_fig_style import apply as _apply_pub_style
+_apply_pub_style()
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.gridspec as gridspec
-_mpl.rcParams["savefig.dpi"]  = 300
 
 REPO = "/hpc/projects/data.science/yangjoon.kim/zebrahub_multiome/zebrahub-multiome-analysis"
 sys.path.insert(0, f"{REPO}/scripts/utils")

--- a/scripts/utils/plot_peaks_locus_view.py
+++ b/scripts/utils/plot_peaks_locus_view.py
@@ -24,15 +24,10 @@ from collections import defaultdict
 import numpy as np
 import pandas as pd
 
-# ── Publication settings ──
-import matplotlib as _mpl
-_mpl.rcParams.update(_mpl.rcParamsDefault)
-_mpl.rcParams['font.family'] = 'Arial'
-_mpl.rcParams["pdf.fonttype"] = 42
-_mpl.rcParams["ps.fonttype"]  = 42
-import seaborn as _sns
-_sns.set(style="whitegrid", context="paper")
-_mpl.rcParams["savefig.dpi"]  = 300
+# ── Publication figure settings (shared module: scripts/utils/pub_fig_style.py) ──
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pub_fig_style import apply as _apply_pub_style
+_apply_pub_style()
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 

--- a/scripts/utils/pub_fig_style.py
+++ b/scripts/utils/pub_fig_style.py
@@ -1,0 +1,55 @@
+"""Publication-quality matplotlib/seaborn style — single source of truth.
+
+Import and call once at the top of any figure script (after importing
+matplotlib/seaborn) and BEFORE drawing:
+
+    from pub_fig_style import apply as apply_pub_style
+    apply_pub_style()
+
+Why this exact order matters (do not reorder):
+  1. reset rcParams to defaults  — clears stale settings from prior imports
+  2. pdf/ps.fonttype = 42         — TrueType embedding → editable text strings
+                                    in Illustrator (the real lever for editable
+                                    text; survives sns.set)
+  3. sns.set(...)                 — applies paper/whitegrid theme; NOTE this
+                                    RESETS both font.family (→ sans-serif) and
+                                    savefig.dpi (→ ~72), so both must be set AFTER
+  4. font.family = 'Arial'        — set AFTER sns.set() or it gets clobbered back
+                                    to sans-serif (this was a latent bug in the
+                                    old inline blocks — Arial never actually took
+                                    effect because it was set before sns.set)
+  5. savefig.dpi = 300            — likewise re-set AFTER sns.set()
+
+Verification: `pdffonts file.pdf` should show `TrueType ArialMT` (fonttype=42).
+Arial is confirmed available in the single-cell-base env; if absent, matplotlib
+warns and falls back to DejaVu Sans (still editable TrueType via fonttype=42).
+
+Reference: feedback_figure_standards.md (user memory); pattern from
+notebooks/Fig2_ATAC_RNA_correlation_metacells/Fig2_metacell_RNA_ATAC_dynamics_v2.py
+"""
+
+import matplotlib as _mpl
+import seaborn as _sns
+
+
+def apply(dpi: int = 300, context: str = "paper", style: str = "whitegrid",
+          font_family: str = "Arial"):
+    """Apply the canonical publication figure style.
+
+    Parameters
+    ----------
+    dpi : int
+        savefig DPI for raster (PNG) exports. Default 300.
+    context : str
+        seaborn context ('paper', 'notebook', 'talk', 'poster'). Default 'paper'.
+    style : str
+        seaborn style. Default 'whitegrid'.
+    font_family : str
+        Font family. Default 'Arial' (forces TrueType embedding on SLURM).
+    """
+    _mpl.rcParams.update(_mpl.rcParamsDefault)   # 1. reset
+    _mpl.rcParams["pdf.fonttype"] = 42           # 2. editable text in Illustrator
+    _mpl.rcParams["ps.fonttype"]  = 42
+    _sns.set(style=style, context=context)       # 3. seaborn (resets font + dpi)
+    _mpl.rcParams["font.family"] = font_family   # 4. Arial AFTER sns.set (or clobbered)
+    _mpl.rcParams["savefig.dpi"]  = dpi          # 5. DPI AFTER sns.set (or clobbered)

--- a/scripts/utils/rank_synthetic_enhancers.py
+++ b/scripts/utils/rank_synthetic_enhancers.py
@@ -37,18 +37,12 @@ from collections import defaultdict
 import numpy as np
 import pandas as pd
 
-# ── Publication figure settings ──
-import matplotlib as _mpl
-_mpl.rcParams.update(_mpl.rcParamsDefault)
-_mpl.rcParams['font.family'] = 'Arial'
-_mpl.rcParams["pdf.fonttype"] = 42
-_mpl.rcParams["ps.fonttype"]  = 42
-import seaborn as _sns
-_sns.set(style="whitegrid", context="paper")
-_mpl.rcParams["savefig.dpi"]  = 300
+# ── Publication figure settings (shared module: scripts/utils/pub_fig_style.py) ──
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pub_fig_style import apply as _apply_pub_style
+_apply_pub_style()
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-_mpl.rcParams["savefig.dpi"]  = 300
 
 REPO = "/hpc/projects/data.science/yangjoon.kim/zebrahub_multiome/zebrahub-multiome-analysis"
 sys.path.insert(0, f"{REPO}/scripts/utils")


### PR DESCRIPTION
## Summary

Session wrap-up housekeeping in three areas.

### 1. Shared publication figure style + ordering-bug fix
- New `scripts/utils/pub_fig_style.py` — single source of truth for the
  matplotlib/seaborn publication style (fonttype=42, Arial, dpi=300, paper/whitegrid).
- Refactored 5 figure scripts to import it instead of each carrying an 8-line copy:
  `rank_synthetic_enhancers`, `make_peak_3panel_figures`, `plot_peaks_locus_view`,
  `compare_motif_function_across_celltypes`, `design_short_element`.
- **Fixes a latent bug:** the old inline blocks set `font.family='Arial'` *before*
  `sns.set()`, but `sns.set()` resets `font.family` back to sans-serif — so figures
  were silently rendering in **DejaVu Sans, not Arial**. The module sets `font.family`
  and `savefig.dpi` *after* `sns.set()` so they actually take effect. Editable text
  was always fine (`pdf.fonttype=42` is the real lever and survives `sns.set`). Arial
  confirmed available in `single-cell-base`. Also removes the redundant double-DPI
  lines in 2 scripts.

### 2. CLAUDE.md — Multi-Database Motif Rescan section
Documents the 09j-family batch FIMO pipeline (H12CORE / JASPAR2024 / CIS-BP v2 danRer)
and points to `MOTIF_DATABASES.md`, giving future sessions an entry point.

### 3. Repo slash commands (`.claude/commands/`)
- `git-wrap.md` — session git-hygiene flow (audit → group commits → PR → cleanup)
- `seff-check.md` — SLURM `seff` resource audit; references/enforces the workspace
  CLAUDE.md monitoring mandate

## Verification
- All 5 refactored scripts import cleanly (`python -c "import <module>"`)
- `pub_fig_style.apply()` confirmed to yield `font.family=Arial`, `pdf.fonttype=42`,
  `savefig.dpi=300`

## Scope
Code + docs + tooling only. No data/binaries. No behavior change to figure *content*
beyond the intended font fix (DejaVu → Arial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)